### PR TITLE
Pipeline: daily apt cache-bust, hash-aware issue reopen, fxb/otel waivers

### DIFF
--- a/.github/scripts/file-cve-issue.js
+++ b/.github/scripts/file-cve-issue.js
@@ -1,10 +1,14 @@
 // Shared helper for the gating jobs in mirror-build.yml.
 //
-// Three kinds:
+// Five kinds:
 //   - 'block'           — Trivy CVE found at build time, push blocked
 //   - 'rescan'          — Trivy CVE detected post-release in the published image
 //   - 'override-review' — upstream Dockerfile changed since last review; the
 //                         override may need updating before the next build
+//   - 'block-resolved'  — Trivy clean at build time; close any open `block`
+//                         issue for this tag (image now passes the gate)
+//   - 'rescan-resolved' — Trivy clean on rescan; close any open `rescan` issue
+//                         for the previously-built tag
 //
 // Idempotency keys are stored as hidden HTML comments in the issue body:
 //
@@ -14,11 +18,21 @@
 //   <!-- findings-cves:CVE-x,CVE-y,... -->        sorted CVE list (CVE kinds only)
 //   <!-- drift-files:path1,path2,... -->          changed Dockerfile paths (override-review only)
 //
-// Behavior:
+// Behavior (filing kinds — block, rescan, override-review):
 //   - No matching open issue       → create new (returns { blocked: true })
 //   - Open issue, hash unchanged   → silent no-op  (returns { blocked: true })
 //   - Open issue, hash changed     → update body + post diff comment (returns { blocked: true })
-//   - Closed issue with this marker → silent no-op  (returns { blocked: false })
+//   - Closed override-review issue → silent no-op (closing an override-review
+//     IS the maintainer's approval, so don't re-open)
+//   - Closed CVE issue (block/rescan), hash unchanged → silent no-op (the
+//     maintainer triaged this exact finding-set; honor the close)
+//   - Closed CVE issue (block/rescan), hash changed → REOPEN + update body +
+//     post diff comment (findings have shifted since the close — likely new
+//     CVEs landed for the same tag, the maintainer needs to see them)
+//
+// Behavior (resolving kinds — block-resolved, rescan-resolved):
+//   - Matching open issue          → comment "resolved by run X" + close (returns { blocked: false })
+//   - No matching issue, or closed → silent no-op (returns { blocked: false })
 //
 // `blocked` lets callers decide whether to fail the workflow step. CVE callers
 // have a separate exit-1 step gated on Trivy outcome; override-review callers
@@ -250,7 +264,7 @@ function extractMarker(body, name) {
 
 module.exports = async function fileCveIssue({ github, context, core, opts }) {
   const { kind, tag, upstream, image, severity, dockerfileSource, jsonPath, jsonPaths, driftPath } = opts;
-  if (!['block', 'rescan', 'override-review'].includes(kind)) {
+  if (!['block', 'rescan', 'override-review', 'block-resolved', 'rescan-resolved'].includes(kind)) {
     throw new Error(`Invalid kind: ${kind}`);
   }
   if (!tag) {
@@ -259,6 +273,42 @@ module.exports = async function fileCveIssue({ github, context, core, opts }) {
 
   const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
   const securityUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/security`;
+
+  // Resolving kinds run before the rest of the filing logic — they don't
+  // produce findings or render a body, just look up an open issue with the
+  // matching marker and close it. Idempotent: a re-run on an already-closed
+  // (or never-existed) issue is a no-op.
+  if (kind === 'block-resolved' || kind === 'rescan-resolved') {
+    const baseKind = kind === 'block-resolved' ? 'block' : 'rescan';
+    const marker = `<!-- mirror-build:cve-${baseKind}:${tag} -->`;
+    const existing = await findExistingIssue({ github, context, marker, labelFilter: 'cve' });
+    if (!existing) {
+      core.info(`No ${baseKind} issue found for tag ${tag} — nothing to clear.`);
+      return { blocked: false };
+    }
+    if (existing.state === 'closed') {
+      core.info(`${baseKind} issue #${existing.number} for tag ${tag} already closed — no-op.`);
+      return { blocked: false };
+    }
+    const reason = baseKind === 'block'
+      ? `Trivy now scans \`${image}:${tag}\` clean; image was pushed.`
+      : `Trivy rescan of \`${image}:${tag}\` is now clean.`;
+    await github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: existing.number,
+      body: `Resolved by [run ${context.runId}](${runUrl}). ${reason} Closing.`,
+    });
+    await github.rest.issues.update({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: existing.number,
+      state: 'closed',
+      state_reason: 'completed',
+    });
+    core.info(`Closed ${baseKind} issue #${existing.number} for tag ${tag}.`);
+    return { blocked: false };
+  }
 
   // Marker, label, title, payload are all kind-specific.
   let marker, title, labels, labelFilter, findings, drift, hashForLog, summaryForLog;
@@ -301,14 +351,32 @@ module.exports = async function fileCveIssue({ github, context, core, opts }) {
     return { blocked: true };
   }
 
-  if (existing.state === 'closed') {
-    core.info(`Found closed issue #${existing.number} for ${marker} — respecting maintainer decision; not re-opening.`);
-    return { blocked: false };
-  }
-
+  // Track whether the existing issue was closed so we can word the comment
+  // and the update payload differently. The closed-issue branch below may
+  // either short-circuit (no-op) or reopen and fall through to the update
+  // path that handles open issues with stale bodies.
+  const wasClosed = existing.state === 'closed';
   const oldHash = extractMarker(existing.body, 'findings-sha256');
   const newHash = (kind === 'override-review' ? drift.hash : findings.hash);
-  if (oldHash === newHash) {
+
+  if (wasClosed) {
+    if (kind === 'override-review') {
+      // Closing an override-review IS the maintainer's "I've reviewed this"
+      // signal — re-opening would override that decision. Honor it.
+      core.info(`Found closed override-review #${existing.number} — respecting maintainer decision; not re-opening.`);
+      return { blocked: false };
+    }
+    // CVE kinds: closing only means "I've seen this finding-set" — it does
+    // NOT mean the CVEs are fixed. If new findings show up against the same
+    // tag (e.g. a new advisory landed overnight), the maintainer needs to be
+    // pulled back in. Honor the close only when the finding-set is bit-for-
+    // bit identical to what they last saw.
+    if (oldHash === newHash) {
+      core.info(`Closed CVE issue #${existing.number} matches current findings (hash ${newHash}); honoring close.`);
+      return { blocked: false };
+    }
+    core.info(`Reopening CVE issue #${existing.number}: findings changed since close (${oldHash || 'none'} → ${newHash}).`);
+  } else if (oldHash === newHash) {
     core.info(`Open issue #${existing.number} already reflects current state (hash ${newHash}). No-op.`);
     return { blocked: true };
   }
@@ -318,10 +386,18 @@ module.exports = async function fileCveIssue({ github, context, core, opts }) {
     repo: context.repo.repo,
     issue_number: existing.number,
     body,
+    // Reopen iff we explicitly decided to above. For already-open issues the
+    // GitHub API treats `state` as a no-op idempotent set, so passing 'open'
+    // is harmless either way — but being explicit keeps the intent clear.
+    state: 'open',
   });
 
   // Diff comment: kind-specific summary of what changed since last update.
-  const lines = [`State changed in [run ${context.runId}](${runUrl}):`, ``];
+  // Lead with "Reopened" wording when applicable so the maintainer sees
+  // immediately why the issue is back in their inbox.
+  const lines = wasClosed
+    ? [`Reopened by [run ${context.runId}](${runUrl}) — findings changed since this issue was closed:`, ``]
+    : [`State changed in [run ${context.runId}](${runUrl}):`, ``];
   if (kind === 'override-review') {
     const oldFilesRaw = extractMarker(existing.body, 'drift-files');
     const oldFiles = new Set(oldFilesRaw ? oldFilesRaw.split(',').filter(Boolean) : []);

--- a/.github/workflows/mirror-build.yml
+++ b/.github/workflows/mirror-build.yml
@@ -341,6 +341,17 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Emit today's UTC date for use as APT_REFRESH build-arg. BuildKit hashes
+      # cache layers on (parent layer + RUN command string) — the apt repo
+      # state is not part of that hash, so an unchanged Dockerfile re-uses
+      # the cached apt layer indefinitely and never picks up new Debian
+      # security updates. Threading this date into the apt-install RUN
+      # invalidates the layer once per UTC day, which matches the Debian
+      # security cadence we promise. Within a day, cache reuse is unaffected.
+      - name: Compute APT_REFRESH date
+        id: apt-refresh
+        run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
       - name: Build image (load, no push)
         id: build
         uses: docker/build-push-action@v6
@@ -353,8 +364,12 @@ jobs:
           # binary's Main.Version. Overrides that don't declare ARG VERSION
           # ignore this silently — backward-compatible with plain upstream
           # Dockerfiles. See README "Module-path patching".
+          # APT_REFRESH busts the apt-install layer cache once per UTC day
+          # (see "Compute APT_REFRESH date" step). Overrides that don't
+          # declare ARG APT_REFRESH ignore it silently.
           build-args: |
             VERSION=${{ needs.check-upstream.outputs.new_tag }}
+            APT_REFRESH=${{ steps.apt-refresh.outputs.date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -440,6 +455,28 @@ jobs:
               },
             });
 
+      # Inverse gate: Trivy passed for this tag this run, so any open `block`
+      # issue from a previous (failing) run for the same tag is now stale.
+      # The helper looks it up by marker, posts a "resolved by run X" comment,
+      # and closes it. No-op if no such issue exists or it's already closed.
+      - name: Close CVE issue if scan clean
+        if: steps.trivy-scan.outcome == 'success' && steps.trivy-fs.outcome == 'success'
+        uses: actions/github-script@v7
+        env:
+          NEW_TAG: ${{ needs.check-upstream.outputs.new_tag }}
+          IMG:     ${{ env.IMAGE_NAME }}
+        with:
+          script: |
+            const fileCveIssue = require('./.github/scripts/file-cve-issue.js');
+            await fileCveIssue({
+              github, context, core,
+              opts: {
+                kind: 'block-resolved',
+                tag: process.env.NEW_TAG,
+                image: process.env.IMG,
+              },
+            });
+
       - name: Upload audit bundle
         uses: actions/upload-artifact@v4
         if: always()
@@ -473,6 +510,7 @@ jobs:
             ${{ env.IMAGE_NAME }}:latest
           build-args: |
             VERSION=${{ needs.check-upstream.outputs.new_tag }}
+            APT_REFRESH=${{ steps.apt-refresh.outputs.date }}
           cache-from: type=gha
 
       # --- Open a PR with the digest pin -------------------------------------
@@ -684,6 +722,27 @@ jobs:
                 image: process.env.IMG,
                 severity: process.env.SEV,
                 jsonPath: 'trivy-rescan.json',
+              },
+            });
+
+      # Inverse gate: rescan passed clean for last_tag, so any open `rescan`
+      # issue from a previous nightly is stale. Same close-on-resolve helper
+      # call as in the build job, with the rescan marker shape.
+      - name: Close rescan issue if rescan clean
+        if: steps.last.outputs.should_scan == 'true' && steps.trivy-rescan.outcome == 'success'
+        uses: actions/github-script@v7
+        env:
+          LAST_TAG: ${{ steps.last.outputs.last_tag }}
+          IMG:      ${{ env.IMAGE_NAME }}
+        with:
+          script: |
+            const fileCveIssue = require('./.github/scripts/file-cve-issue.js');
+            await fileCveIssue({
+              github, context, core,
+              opts: {
+                kind: 'rescan-resolved',
+                tag: process.env.LAST_TAG,
+                image: process.env.IMG,
               },
             });
 

--- a/.trivyignore
+++ b/.trivyignore
@@ -145,6 +145,31 @@ CVE-2026-41242
 # upstream redbean-node release), or 2026-11.
 CVE-2026-4800
 
+# CVE-2026-44665 — fast-xml-builder@1.1.5 attribute-quote bypass (HIGH).
+# Fix in fast-xml-builder 1.1.7. uptime-kuma 2.3.2 pulls 1.1.5 transitively:
+#
+#   mongodb (optionalDependencies)
+#    -> @aws-sdk/credential-providers
+#        -> @aws-sdk/core
+#            -> @aws-sdk/xml-builder
+#                -> fast-xml-parser
+#                    -> fast-xml-builder
+#
+# Three independent reasons the CVE is unreachable in this image:
+#  1. Optional path: the @aws-sdk chain only loads when a MongoDB monitor
+#     is configured with AWS-IAM auth (MongoDB Atlas). Not used here.
+#  2. Wrong protocol class: @aws-sdk/xml-builder constructs XML request
+#     bodies for S3/SES/SQS/SNS. The only AWS client present in this
+#     dependency chain is @aws-sdk/client-cognito-identity, which speaks
+#     JSON / query-string — xml-builder is never invoked along this path.
+#  3. CVE shape: it's an output-encoding bug requiring attacker-controlled
+#     values to be passed as XML attribute strings in outgoing AWS
+#     requests. All AWS-call inputs in uptime-kuma originate from
+#     admin-supplied monitor config, not from external probe targets.
+#
+# Revisit when louislam bumps mongodb / fast-xml-parser, or by 2026-08-09.
+CVE-2026-44665
+
 # ============================================================================
 # Go-binary findings — vendored in cloudflared (the tunnel client we install
 # from Cloudflare's apt repo). cloudflared is run only when the user
@@ -211,3 +236,18 @@ CVE-2026-34986
 #
 # Revisit when Cloudflare ships a fresh cloudflared .deb, or 2026-09.
 CVE-2026-39883
+
+# CVE-2026-29181 — go.opentelemetry.io/otel multi-value `baggage` header
+# extraction allocates excessively (HIGH, remote DoS amplification).
+# Fix in otel 1.41.0. Vendored inside cloudflared at v1.40.0.
+#
+# Affected codepath: otel's HTTP propagator parses incoming `baggage`
+# headers on a server endpoint. cloudflared in this image runs as the
+# tunnel CLIENT — outbound to Cloudflare's edge, not a local HTTP server.
+# An attacker can only reach an inbound baggage parser by compromising
+# Cloudflare's edge first, which is outside our threat model. The
+# in-container `cloudflared metrics` HTTP server is bound to a Unix
+# socket / localhost only, reachable only by the in-container `node` UID.
+#
+# Revisit when Cloudflare ships a fresh cloudflared .deb, or 2026-09.
+CVE-2026-29181

--- a/dockerfiles/Dockerfile.override
+++ b/dockerfiles/Dockerfile.override
@@ -82,6 +82,17 @@ RUN apt-get update && \
 FROM ${NODE_BASE} AS base
 ARG TARGETPLATFORM
 
+# APT_REFRESH is a daily UTC date string forwarded by the CI workflow
+# (mirror-build.yml: "Compute APT_REFRESH date" step). BuildKit hashes
+# RUN layers on (parent + command string) — without this arg, an
+# unchanged Dockerfile re-uses the cached apt layer forever and never
+# picks up new Debian security advisories. Threading the date into the
+# first apt-using RUN below bumps the hash once per UTC day, which is
+# the cadence Debian publishes security updates at. Within a day, cache
+# reuse is unaffected. Default `unset` keeps local `docker build` runs
+# working without the build-arg.
+ARG APT_REFRESH=unset
+
 # OCI labels surface this image as our build, not louislam's, on inspect.
 LABEL org.opencontainers.image.source="https://github.com/louislam/uptime-kuma" \
       org.opencontainers.image.licenses="MIT" \
@@ -91,8 +102,11 @@ LABEL org.opencontainers.image.source="https://github.com/louislam/uptime-kuma" 
 
 # 3a. Slim-base apt set — same as upstream's :base2-slim minus chromium/maria.
 # `apt-get -y autoremove` after each install cleans up build-only deps that
-# slipped in via Recommends despite --no-install-recommends.
-RUN apt-get update && \
+# slipped in via Recommends despite --no-install-recommends. The first line
+# threads APT_REFRESH into this layer's hash so daily rebuilds re-resolve
+# apt rather than reusing a stale cached layer (see ARG APT_REFRESH above).
+RUN echo "apt-refresh=${APT_REFRESH}" > /etc/.apt-refresh && \
+    apt-get update && \
     apt-get install --no-install-recommends -y \
       sqlite3 \
       ca-certificates \


### PR DESCRIPTION
## Summary
- **`file-cve-issue.js`**: closed CVE-block issues are now reopened when the findings hash changes, instead of being silently honored. Same model as override-review still differs (closing override-review = approval).
- **APT_REFRESH cache-bust**: daily UTC date threaded into the apt-install RUN layer so BuildKit's GHA cache invalidates once per day. Unblocks pulling fresh Debian security updates without changing the Dockerfile.
- **`.trivyignore`**: two new waivers with full reachability analysis — fast-xml-builder@1.1.5 (CVE-2026-44665, transitive via mongodb optionalDeps → AWS SDK; xml-builder never invoked in cognito JSON path) and cloudflared otel v1.40.0 (CVE-2026-29181, baggage-header DoS only reachable via inbound HTTP, cloudflared runs as outbound client).

## Why this matters now
- Issue #4 (`cve-block:2.3.2`) was closed on 2026-05-04; today's manual workflow_dispatch runs found CVEs but the old logic logged "respecting maintainer decision; not re-opening" and didn't update anything. With the new logic, mismatched hash on a closed CVE issue → reopen + diff comment.
- After cache-bust, image scan drops from 164 → 2 CRITICAL/HIGH; the two remaining findings are addressed by the new waivers.

## Test plan
- [ ] Merge to main
- [ ] `workflow_dispatch` on main
- [ ] Verify Issue #4 is reopened with body listing `CVE-2026-29181 + CVE-2026-44665` only, plus a "Cleared: …" comment listing the dropped chromium CVEs
- [ ] Verify build pushes (Trivy now clean after waivers)
- [ ] Verify `mirror-build/2.3.2` PR opens with new digest pin