### PR TITLE
ci: unify CVE issue per tag (build + rescan share one issue)

### DIFF
--- a/.github/scripts/file-cve-issue.js
+++ b/.github/scripts/file-cve-issue.js
@@ -362,6 +362,53 @@ function extractMarker(body, name) {
   return m ? m[1].trim() : null;
 }
 
+async function closeAssociatedMirrorBuildPR({ github, context, core, tag, issueNumber, runUrl }) {
+  // When a CVE issue surfaces findings against a tag that already has an
+  // open mirror-build/<tag> PR (e.g. yesterday's build pushed clean, today's
+  // rescan flagged the deployed image), close the PR so it can't merge into
+  // a known-vulnerable rollout. Self-heals: a subsequent clean build
+  // force-pushes the branch and the workflow's PR-open step files a fresh PR.
+  // Maintainer override: manually re-open the PR to accept the finding.
+  const branchTag = tag.replace(/\//g, '-');
+  const branch = `mirror-build/${branchTag}`;
+  let prs;
+  try {
+    const { data } = await github.rest.pulls.list({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      head: `${context.repo.owner}:${branch}`,
+      state: 'open',
+    });
+    prs = data;
+  } catch (e) {
+    core.warning(`Could not list PRs for branch ${branch}: ${e.message}`);
+    return;
+  }
+  if (prs.length === 0) {
+    core.info(`No open PR for ${branch} — nothing to close.`);
+    return;
+  }
+  for (const pr of prs) {
+    try {
+      await github.rest.issues.createComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: pr.number,
+        body: `Auto-closed: CVE issue #${issueNumber} surfaced findings against tag \`${tag}\` ([run ${context.runId}](${runUrl})).\n\nMerging this PR would deploy a known-vulnerable image. Fix the underlying issue (waiver / upgrade / upstream patch) and re-run the workflow to file a fresh PR against the next clean digest. To override, re-open this PR manually — the decision then carries your audit trail.`,
+      });
+      await github.rest.pulls.update({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        pull_number: pr.number,
+        state: 'closed',
+      });
+      core.info(`Closed PR #${pr.number} on branch ${branch} due to CVE issue #${issueNumber}.`);
+    } catch (e) {
+      core.warning(`Failed to close PR #${pr.number}: ${e.message}`);
+    }
+  }
+}
+
 async function handleOverrideReview({ github, context, core, opts, runUrl }) {
   const { tag, upstream, driftPath } = opts;
   const marker = `<!-- mirror-build:override-review:${tag} -->`;
@@ -515,6 +562,7 @@ module.exports = async function fileCveIssue({ github, context, core, opts }) {
       labels: ['cve', 'security'],
     });
     core.info(`Created issue #${created.data.number} for tag ${tag} (source: ${source}, ${findings.cves.length} CVEs, hash: ${findings.hash}).`);
+    await closeAssociatedMirrorBuildPR({ github, context, core, tag, issueNumber: created.data.number, runUrl });
     return { blocked: true };
   }
 
@@ -589,5 +637,6 @@ module.exports = async function fileCveIssue({ github, context, core, opts }) {
     body: lines.join('\n'),
   });
   core.info(`Updated issue #${existing.number}: hash ${oldHash || 'none'} → ${newHash}, source ${currentSource || 'none'} → ${source}.`);
+  await closeAssociatedMirrorBuildPR({ github, context, core, tag, issueNumber: existing.number, runUrl });
   return { blocked: true };
 };

--- a/.github/scripts/file-cve-issue.js
+++ b/.github/scripts/file-cve-issue.js
@@ -1,42 +1,59 @@
 // Shared helper for the gating jobs in mirror-build.yml.
 //
-// Five kinds:
-//   - 'block'           — Trivy CVE found at build time, push blocked
-//   - 'rescan'          — Trivy CVE detected post-release in the published image
-//   - 'override-review' — upstream Dockerfile changed since last review; the
-//                         override may need updating before the next build
-//   - 'block-resolved'  — Trivy clean at build time; close any open `block`
-//                         issue for this tag (image now passes the gate)
-//   - 'rescan-resolved' — Trivy clean on rescan; close any open `rescan` issue
-//                         for the previously-built tag
+// Three kinds:
+//   - 'cve-findings'    — Trivy detected CVEs (source: 'build' or 'rescan')
+//   - 'cve-resolved'    — Trivy clean       (source: 'build' or 'rescan')
+//   - 'override-review' — upstream Dockerfile changed since last review
 //
-// Idempotency keys are stored as hidden HTML comments in the issue body:
+// Per-tag identity: one issue tracks the entire lifetime of a given upstream
+// tag. The marker <!-- mirror-build:cve:<tag> --> is repo-unique. Both
+// build-time and post-release-rescan events update the same issue; the body
+// always reflects the most recent scan, with a header line identifying the
+// source. Comments preserve the chronological history (added/cleared CVEs,
+// state transitions). Closed issues stay in the system; a new finding
+// reopens them. This gives a per-version audit trail without spawning a new
+// issue for every event.
 //
-//   <!-- mirror-build:cve-<kind>:<tag> -->        identifier (kind ∈ {block, rescan})
-//   <!-- mirror-build:override-review:<tag> -->   identifier (kind = override-review)
-//   <!-- findings-sha256:<short-hash> -->         fingerprint of current findings/drift
-//   <!-- findings-cves:CVE-x,CVE-y,... -->        sorted CVE list (CVE kinds only)
-//   <!-- drift-files:path1,path2,... -->          changed Dockerfile paths (override-review only)
+// Markers embedded in the issue body:
 //
-// Behavior (filing kinds — block, rescan, override-review):
-//   - No matching open issue       → create new (returns { blocked: true })
-//   - Open issue, hash unchanged   → silent no-op  (returns { blocked: true })
-//   - Open issue, hash changed     → update body + post diff comment (returns { blocked: true })
-//   - Closed override-review issue → silent no-op (closing an override-review
-//     IS the maintainer's approval, so don't re-open)
-//   - Closed CVE issue (block/rescan), hash unchanged → silent no-op (the
-//     maintainer triaged this exact finding-set; honor the close)
-//   - Closed CVE issue (block/rescan), hash changed → REOPEN + update body +
-//     post diff comment (findings have shifted since the close — likely new
-//     CVEs landed for the same tag, the maintainer needs to see them)
+//   <!-- mirror-build:cve:<tag> -->           identifier (CVE kinds)
+//   <!-- mirror-build:override-review:<tag> --> identifier (override-review)
+//   <!-- last-scan-source:build|rescan -->    who last wrote the body
+//   <!-- last-scan-status:open|resolved -->   findings present (open) or not
+//   <!-- findings-sha256:<short-hash> -->     fingerprint for change detection
+//   <!-- findings-cves:CVE-x,CVE-y,... -->    sorted CVE list (for diff comments)
+//   <!-- drift-files:path1,path2,... -->      changed Dockerfile paths (override-review only)
 //
-// Behavior (resolving kinds — block-resolved, rescan-resolved):
-//   - Matching open issue          → comment "resolved by run X" + close (returns { blocked: false })
-//   - No matching issue, or closed → silent no-op (returns { blocked: false })
+// Pending-build override:
+//   When a rescan runs and finds the issue with last-scan-source=build AND
+//   last-scan-status=open (build is currently blocked, hasn't pushed), the
+//   rescan does NOT update the body. It posts a comment with its findings so
+//   the audit trail is preserved, but the body keeps showing the pending
+//   build's view. Build retains write priority on the body until it resolves
+//   (push succeeds or maintainer closes the issue).
 //
-// `blocked` lets callers decide whether to fail the workflow step. CVE callers
-// have a separate exit-1 step gated on Trivy outcome; override-review callers
-// gate on the helper's `blocked` output directly.
+// Legacy migration:
+//   First invocation against a tag also checks for the pre-unification markers
+//   <!-- mirror-build:cve-block:<tag> --> and <!-- mirror-build:cve-rescan:<tag> -->.
+//   If found, the highest-numbered legacy issue is adopted (new marker prepended
+//   to its body) and any other legacy issues are closed with a "superseded by"
+//   comment. Idempotent: subsequent runs find the new marker directly.
+//
+// Behavior (cve-findings):
+//   - No matching issue, no legacy   → create new issue, body = current scan
+//   - Existing issue, body unchanged → silent no-op
+//   - Existing issue, body changed   → update body + diff comment
+//   - Existing closed, hash matches  → honor close (maintainer triaged this set)
+//   - Existing closed, hash differs  → reopen + update body + diff comment
+//   - Pending-build override active  → rescan posts comment only, body untouched
+//
+// Behavior (cve-resolved):
+//   - No matching issue              → no-op (nothing to clean up)
+//   - Open issue, build resolution   → update body to 'resolved' + close
+//   - Open issue, rescan resolution while build pending → comment only (build owns body)
+//   - Already closed                 → no-op
+//
+// Behavior (override-review): unchanged from previous version.
 
 const fs = require('fs');
 const crypto = require('crypto');
@@ -44,10 +61,6 @@ const crypto = require('crypto');
 const SEV_RANK = { CRITICAL: 0, HIGH: 1, MEDIUM: 2, LOW: 3, UNKNOWN: 4 };
 
 function loadFindings(jsonPaths) {
-  // Accept a single path (legacy) or an array of paths. Multiple inputs are
-  // useful when scanning the same release through several Trivy modes (image
-  // + fs) — the resulting rows are merged and deduplicated so the issue body
-  // shows one combined table per tag.
   const paths = Array.isArray(jsonPaths) ? jsonPaths : (jsonPaths ? [jsonPaths] : []);
   const present = paths.filter(p => p && fs.existsSync(p));
   if (present.length === 0) {
@@ -63,8 +76,6 @@ function loadFindings(jsonPaths) {
       errors.push(`\`${path}\`: ${e.message}`);
       continue;
     }
-    // Trivy emits the same Results[].Vulnerabilities[] schema for both image
-    // and fs scans. The Class/Type fields differ but rows are merge-compatible.
     for (const result of data.Results || []) {
       for (const v of result.Vulnerabilities || []) {
         rows.push({
@@ -81,9 +92,6 @@ function loadFindings(jsonPaths) {
   if (errors.length && rows.length === 0) {
     return { rows: [], cves: [], hash: 'parse-error', table: `_Failed to parse Trivy JSON: ${errors.join('; ')}_` };
   }
-  // Dedup identical (CVE, pkg, installed, fixed) tuples — same finding across
-  // image + fs scans (e.g. an OS package both detected in apk db and in a
-  // language manifest) collapses into one row.
   const seen = new Set();
   const deduped = [];
   for (const r of rows) {
@@ -109,7 +117,6 @@ function loadFindings(jsonPaths) {
   const tableBody = rows
     .map(r => `| ${r.cve} | ${r.severity} | \`${escape(r.pkg)}\` | ${escape(r.installed)} | ${escape(r.fixed)} | ${escape(r.title)} |`)
     .join('\n');
-  // Fingerprint: stable across runs as long as the (CVE, package, installed, fixed) tuples don't change.
   const fingerprint = rows.map(r => `${r.cve}|${r.pkg}|${r.installed}|${r.fixed}`).sort().join('\n');
   const hash = crypto.createHash('sha256').update(fingerprint).digest('hex').slice(0, 16);
   const cves = [...new Set(rows.map(r => r.cve))].sort();
@@ -117,13 +124,6 @@ function loadFindings(jsonPaths) {
 }
 
 function loadDrift(driftPath) {
-  // Build a "findings-shaped" object for an override-review issue from a
-  // git-diff patch file containing the upstream Dockerfile changes.
-  //
-  // Returns { files, hash, table } where:
-  //   - files: list of path headers extracted from the diff (for the comment)
-  //   - hash:  sha256 of the patch content (for change detection)
-  //   - table: fenced ```diff block with the patch body (for the issue body)
   if (!driftPath || !fs.existsSync(driftPath)) {
     return { files: [], hash: 'none', table: '_No drift patch produced._' };
   }
@@ -136,8 +136,6 @@ function loadDrift(driftPath) {
     const m = line.match(/^diff --git a\/(\S+) b\//);
     if (m) files.push(m[1]);
   }
-  // Truncate very large patches in the issue body so the GitHub UI stays usable.
-  // Reviewers can still read the full patch in audit/dockerfile-drift.patch.
   const MAX = 12000;
   const truncated = patch.length > MAX
     ? patch.slice(0, MAX) + `\n... (truncated; full patch in audit bundle, ${patch.length - MAX} more chars)`
@@ -146,81 +144,55 @@ function loadDrift(driftPath) {
   return { files, hash, table: '```diff\n' + truncated + '\n```' };
 }
 
-function renderBody({ marker, kind, tag, upstream, image, severity, dockerfileSource, findings, drift, runUrl, securityUrl }) {
-  if (kind === 'override-review') {
-    const filesMarker = `<!-- drift-files:${drift.files.join(',')} -->`;
-    const hashMarker = `<!-- findings-sha256:${drift.hash} -->`;
-    const preamble = [
-      `Upstream changed one or more Dockerfile paths between the last reviewed tag and \`${tag}\`.`,
-      ``,
-      `**The build is blocked** until the override is reconfirmed against the new upstream Dockerfile.`,
-      ``,
-      `- Upstream: \`${upstream || 'unknown'}\``,
-      `- Affected paths: ${drift.files.length ? drift.files.map(f => `\`${f}\``).join(', ') : '_(none parsed)_'}`,
-    ].join('\n');
-    const action = [
-      `**Reviewer checklist:**`,
-      `- [ ] Read the diff below and decide whether \`dockerfiles/Dockerfile.override\` needs updating`,
-      `- [ ] If yes: open a PR updating the override; merge to \`main\`; close this issue`,
-      `- [ ] If no: just close this issue (signals "override is still correct for this upstream")`,
-      ``,
-      `Closing this issue unblocks the build. Re-run the workflow via \`workflow_dispatch\` after closing — the gate is idempotent: the closed marker satisfies it without re-filing.`,
-    ].join('\n');
-    return [
-      marker,
-      ``,
-      preamble,
-      ``,
-      `## Upstream Dockerfile diff (${tag})`,
-      ``,
-      drift.table,
-      ``,
-      `## Links`,
-      `- [Workflow run](${runUrl}) — full diff + audit bundle`,
-      ``,
-      action,
-      ``,
-      filesMarker,
-      hashMarker,
-    ].join('\n');
-  }
-
-  const cvesMarker = `<!-- findings-cves:${findings.cves.join(',')} -->`;
+function renderCveBody({ tag, upstream, image, severity, dockerfileSource, findings, source, status, runUrl, securityUrl }) {
+  const marker = `<!-- mirror-build:cve:${tag} -->`;
+  const sourceMarker = `<!-- last-scan-source:${source} -->`;
+  const statusMarker = `<!-- last-scan-status:${status} -->`;
   const hashMarker = `<!-- findings-sha256:${findings.hash} -->`;
+  const cvesMarker = `<!-- findings-cves:${findings.cves.join(',')} -->`;
 
-  let preamble;
+  const sourceLabel = source === 'build'
+    ? 'build-time scan (fs + image)'
+    : 'post-release rescan (image only)';
+  const statusLabel = status === 'resolved'
+    ? 'clean — no CRITICAL/HIGH findings with available fix'
+    : `${findings.cves.length} unique CVE${findings.cves.length === 1 ? '' : 's'}`;
+  const timestamp = new Date().toISOString();
+
+  const headerLines = [
+    `**Last scan:** ${sourceLabel} — ${statusLabel}`,
+    `**Run:** [${timestamp}](${runUrl})`,
+    `**Image:** \`${image}:${tag}\``,
+    `**Upstream:** \`${upstream || 'unknown'}\``,
+  ];
+  if (dockerfileSource) headerLines.push(`**Dockerfile source:** \`${dockerfileSource}\``);
+
+  const findingsSection = status === 'resolved'
+    ? `## Findings\n\n_No CRITICAL or HIGH findings with available fix._`
+    : `## Findings (${findings.cves.length} unique CVE${findings.cves.length === 1 ? '' : 's'})\n\n${findings.table}`;
+
   let action;
-  if (kind === 'block') {
-    preamble = [
-      `Trivy found ${severity} vulnerabilities in \`${image}:${tag}\`.`,
-      ``,
-      `**Image was NOT pushed.**`,
-      ``,
-      `- Upstream: \`${upstream || 'unknown'}\``,
-      `- Dockerfile source: \`${dockerfileSource || 'unknown'}\``,
-    ].join('\n');
-    action = `Next step: review the diff, decide whether to wait for an upstream fix or add an ignore with justification to \`.trivyignore\`.`;
+  if (status === 'resolved') {
+    action = `_Tracking record kept open for audit history. Will reopen if a future scan finds new CVEs against this tag._`;
+  } else if (source === 'build') {
+    action = `**Image was NOT pushed.** Next step: review the diff, decide whether to wait for an upstream fix or add an ignore with justification to \`.trivyignore\`.`;
   } else {
-    preamble = [
-      `A nightly rescan of the already-built and published image \`${image}:${tag}\` surfaced ${severity} Trivy findings.`,
-      ``,
-      `These CVEs were not necessarily known when the image was originally built — the CVE database advanced. The image is unchanged.`,
-    ].join('\n');
     action = [
+      `These CVEs were not necessarily known when the image was originally built — the CVE database advanced. The deployed image is unchanged.`,
+      ``,
       `**Action options:**`,
-      `- Wait for an upstream release that fixes the affected dependency (typical).`,
+      `- Wait for an upstream release that fixes the affected dependency.`,
       `- Roll a Dockerfile-override-level pin or patch, then trigger a fresh build via \`workflow_dispatch\`.`,
+      `- Add a waiver to \`.trivyignore\` with attack-vector justification.`,
     ].join('\n');
   }
 
   return [
     marker,
     ``,
-    preamble,
+    headerLines.join('\n'),
     ``,
-    `## Findings (${findings.cves.length} unique CVE${findings.cves.length === 1 ? '' : 's'})`,
-    ``,
-    findings.table,
+    findingsSection,
     ``,
     `## Links`,
     `- [Workflow run](${runUrl}) — SARIF + audit bundle`,
@@ -228,14 +200,53 @@ function renderBody({ marker, kind, tag, upstream, image, severity, dockerfileSo
     ``,
     action,
     ``,
+    sourceMarker,
+    statusMarker,
+    hashMarker,
     cvesMarker,
+  ].join('\n');
+}
+
+function renderOverrideReviewBody({ tag, upstream, drift, runUrl }) {
+  const marker = `<!-- mirror-build:override-review:${tag} -->`;
+  const filesMarker = `<!-- drift-files:${drift.files.join(',')} -->`;
+  const hashMarker = `<!-- findings-sha256:${drift.hash} -->`;
+  const preamble = [
+    `Upstream changed one or more Dockerfile paths between the last reviewed tag and \`${tag}\`.`,
+    ``,
+    `**The build is blocked** until the override is reconfirmed against the new upstream Dockerfile.`,
+    ``,
+    `- Upstream: \`${upstream || 'unknown'}\``,
+    `- Affected paths: ${drift.files.length ? drift.files.map(f => `\`${f}\``).join(', ') : '_(none parsed)_'}`,
+  ].join('\n');
+  const action = [
+    `**Reviewer checklist:**`,
+    `- [ ] Read the diff below and decide whether \`dockerfiles/Dockerfile.override\` needs updating`,
+    `- [ ] If yes: open a PR updating the override; merge to \`main\`; close this issue`,
+    `- [ ] If no: just close this issue (signals "override is still correct for this upstream")`,
+    ``,
+    `Closing this issue unblocks the build. Re-run the workflow via \`workflow_dispatch\` after closing — the gate is idempotent: the closed marker satisfies it without re-filing.`,
+  ].join('\n');
+  return [
+    marker,
+    ``,
+    preamble,
+    ``,
+    `## Upstream Dockerfile diff (${tag})`,
+    ``,
+    drift.table,
+    ``,
+    `## Links`,
+    `- [Workflow run](${runUrl}) — full diff + audit bundle`,
+    ``,
+    action,
+    ``,
+    filesMarker,
     hashMarker,
   ].join('\n');
 }
 
-async function findExistingIssue({ github, context, marker, labelFilter }) {
-  // Real-time list (search index has indexing delay), filtered client-side by marker.
-  // Listing by label keeps the page count small.
+async function findIssueByMarker({ github, context, marker, labelFilter }) {
   for (const state of ['open', 'closed']) {
     const iter = github.paginate.iterator(github.rest.issues.listForRepo, {
       owner: context.repo.owner,
@@ -256,128 +267,129 @@ async function findExistingIssue({ github, context, marker, labelFilter }) {
   return null;
 }
 
+async function findLegacyCveIssues({ github, context, tag }) {
+  // Pre-unification markers from before the cve:<tag> consolidation. Used
+  // by the migration path on first run against an existing tag.
+  const legacyMarkers = [
+    `<!-- mirror-build:cve-block:${tag} -->`,
+    `<!-- mirror-build:cve-rescan:${tag} -->`,
+  ];
+  const found = [];
+  for (const state of ['open', 'closed']) {
+    const iter = github.paginate.iterator(github.rest.issues.listForRepo, {
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      state,
+      labels: 'cve',
+      per_page: 100,
+    });
+    for await (const { data } of iter) {
+      for (const issue of data) {
+        if (issue.pull_request) continue;
+        if (!issue.body) continue;
+        for (const marker of legacyMarkers) {
+          if (issue.body.includes(marker)) {
+            found.push(issue);
+            break;
+          }
+        }
+      }
+    }
+  }
+  return found;
+}
+
+async function adoptOrMigrateLegacy({ github, context, core, tag, newMarker }) {
+  // Returns the canonical issue (refreshed) if migration happened, else null.
+  // Highest-numbered legacy issue is picked as canonical (most recent); the
+  // others are closed as superseded so the tracker reflects one issue per tag.
+  const legacy = await findLegacyCveIssues({ github, context, tag });
+  if (legacy.length === 0) return null;
+
+  legacy.sort((a, b) => b.number - a.number);
+  const canonical = legacy[0];
+  const others = legacy.slice(1);
+
+  const patchedBody = canonical.body.includes(newMarker)
+    ? canonical.body
+    : `${newMarker}\n\n${canonical.body}`;
+  if (patchedBody !== canonical.body) {
+    await github.rest.issues.update({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: canonical.number,
+      body: patchedBody,
+    });
+    await github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: canonical.number,
+      body: `Migrated to unified per-tag CVE tracking. This issue is now canonical for tag \`${tag}\` across both build-time and rescan findings.`,
+    });
+    core.info(`Migrated issue #${canonical.number} to ${newMarker}.`);
+  }
+
+  for (const dupe of others) {
+    await github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: dupe.number,
+      body: `Superseded by #${canonical.number} — consolidated under unified per-tag CVE tracking.`,
+    });
+    if (dupe.state !== 'closed') {
+      await github.rest.issues.update({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: dupe.number,
+        state: 'closed',
+        state_reason: 'duplicate',
+      });
+    }
+    core.info(`Closed legacy issue #${dupe.number} as duplicate of #${canonical.number}.`);
+  }
+
+  const { data: refreshed } = await github.rest.issues.get({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: canonical.number,
+  });
+  return refreshed;
+}
+
 function extractMarker(body, name) {
   const re = new RegExp(`<!-- ${name}:([^>]*) -->`);
   const m = (body || '').match(re);
   return m ? m[1].trim() : null;
 }
 
-module.exports = async function fileCveIssue({ github, context, core, opts }) {
-  const { kind, tag, upstream, image, severity, dockerfileSource, jsonPath, jsonPaths, driftPath } = opts;
-  if (!['block', 'rescan', 'override-review', 'block-resolved', 'rescan-resolved'].includes(kind)) {
-    throw new Error(`Invalid kind: ${kind}`);
-  }
-  if (!tag) {
-    throw new Error('tag is required');
-  }
+async function handleOverrideReview({ github, context, core, opts, runUrl }) {
+  const { tag, upstream, driftPath } = opts;
+  const marker = `<!-- mirror-build:override-review:${tag} -->`;
+  const drift = loadDrift(driftPath);
+  const body = renderOverrideReviewBody({ tag, upstream, drift, runUrl });
+  const title = `Override review required: ${upstream || tag} @ ${tag}`;
+  const labels = ['override-review', 'blocked'];
 
-  const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-  const securityUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/security`;
-
-  // Resolving kinds run before the rest of the filing logic — they don't
-  // produce findings or render a body, just look up an open issue with the
-  // matching marker and close it. Idempotent: a re-run on an already-closed
-  // (or never-existed) issue is a no-op.
-  if (kind === 'block-resolved' || kind === 'rescan-resolved') {
-    const baseKind = kind === 'block-resolved' ? 'block' : 'rescan';
-    const marker = `<!-- mirror-build:cve-${baseKind}:${tag} -->`;
-    const existing = await findExistingIssue({ github, context, marker, labelFilter: 'cve' });
-    if (!existing) {
-      core.info(`No ${baseKind} issue found for tag ${tag} — nothing to clear.`);
-      return { blocked: false };
-    }
-    if (existing.state === 'closed') {
-      core.info(`${baseKind} issue #${existing.number} for tag ${tag} already closed — no-op.`);
-      return { blocked: false };
-    }
-    const reason = baseKind === 'block'
-      ? `Trivy now scans \`${image}:${tag}\` clean; image was pushed.`
-      : `Trivy rescan of \`${image}:${tag}\` is now clean.`;
-    await github.rest.issues.createComment({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      issue_number: existing.number,
-      body: `Resolved by [run ${context.runId}](${runUrl}). ${reason} Closing.`,
-    });
-    await github.rest.issues.update({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      issue_number: existing.number,
-      state: 'closed',
-      state_reason: 'completed',
-    });
-    core.info(`Closed ${baseKind} issue #${existing.number} for tag ${tag}.`);
-    return { blocked: false };
-  }
-
-  // Marker, label, title, payload are all kind-specific.
-  let marker, title, labels, labelFilter, findings, drift, hashForLog, summaryForLog;
-  if (kind === 'override-review') {
-    marker = `<!-- mirror-build:override-review:${tag} -->`;
-    title = `Override review required: ${upstream || image} @ ${tag}`;
-    labels = ['override-review', 'blocked'];
-    labelFilter = 'override-review';
-    drift = loadDrift(driftPath);
-    hashForLog = drift.hash;
-    summaryForLog = `${drift.files.length} changed path${drift.files.length === 1 ? '' : 's'}`;
-  } else {
-    marker = `<!-- mirror-build:cve-${kind}:${tag} -->`;
-    title = kind === 'block'
-      ? `CVE found: ${upstream || image} @ ${tag}`
-      : `New CVE detected in deployed image ${tag} (post-release)`;
-    labels = kind === 'block'
-      ? ['security', 'cve', 'blocked']
-      : ['security', 'cve', 'rescan'];
-    labelFilter = 'cve';
-    // jsonPaths (array) takes precedence; jsonPath (string) is the legacy form.
-    findings = loadFindings(jsonPaths || jsonPath);
-    hashForLog = findings.hash;
-    summaryForLog = `${findings.cves.length} CVE${findings.cves.length === 1 ? '' : 's'}`;
-  }
-
-  const body = renderBody({ marker, kind, tag, upstream, image, severity, dockerfileSource, findings, drift, runUrl, securityUrl });
-
-  const existing = await findExistingIssue({ github, context, marker, labelFilter });
+  const existing = await findIssueByMarker({ github, context, marker, labelFilter: 'override-review' });
 
   if (!existing) {
     const created = await github.rest.issues.create({
       owner: context.repo.owner,
       repo: context.repo.repo,
-      title,
-      body,
-      labels,
+      title, body, labels,
     });
-    core.info(`Created issue #${created.data.number} for ${marker} (hash ${hashForLog}, ${summaryForLog}).`);
+    core.info(`Created override-review issue #${created.data.number} (hash ${drift.hash}, ${drift.files.length} files).`);
     return { blocked: true };
   }
 
-  // Track whether the existing issue was closed so we can word the comment
-  // and the update payload differently. The closed-issue branch below may
-  // either short-circuit (no-op) or reopen and fall through to the update
-  // path that handles open issues with stale bodies.
-  const wasClosed = existing.state === 'closed';
-  const oldHash = extractMarker(existing.body, 'findings-sha256');
-  const newHash = (kind === 'override-review' ? drift.hash : findings.hash);
+  if (existing.state === 'closed') {
+    core.info(`Override-review #${existing.number} is closed — respecting maintainer decision.`);
+    return { blocked: false };
+  }
 
-  if (wasClosed) {
-    if (kind === 'override-review') {
-      // Closing an override-review IS the maintainer's "I've reviewed this"
-      // signal — re-opening would override that decision. Honor it.
-      core.info(`Found closed override-review #${existing.number} — respecting maintainer decision; not re-opening.`);
-      return { blocked: false };
-    }
-    // CVE kinds: closing only means "I've seen this finding-set" — it does
-    // NOT mean the CVEs are fixed. If new findings show up against the same
-    // tag (e.g. a new advisory landed overnight), the maintainer needs to be
-    // pulled back in. Honor the close only when the finding-set is bit-for-
-    // bit identical to what they last saw.
-    if (oldHash === newHash) {
-      core.info(`Closed CVE issue #${existing.number} matches current findings (hash ${newHash}); honoring close.`);
-      return { blocked: false };
-    }
-    core.info(`Reopening CVE issue #${existing.number}: findings changed since close (${oldHash || 'none'} → ${newHash}).`);
-  } else if (oldHash === newHash) {
-    core.info(`Open issue #${existing.number} already reflects current state (hash ${newHash}). No-op.`);
+  const oldHash = extractMarker(existing.body, 'findings-sha256');
+  if (oldHash === drift.hash) {
+    core.info(`Override-review #${existing.number} already reflects current drift (hash ${drift.hash}). No-op.`);
     return { blocked: true };
   }
 
@@ -386,36 +398,188 @@ module.exports = async function fileCveIssue({ github, context, core, opts }) {
     repo: context.repo.repo,
     issue_number: existing.number,
     body,
-    // Reopen iff we explicitly decided to above. For already-open issues the
-    // GitHub API treats `state` as a no-op idempotent set, so passing 'open'
-    // is harmless either way — but being explicit keeps the intent clear.
     state: 'open',
   });
 
-  // Diff comment: kind-specific summary of what changed since last update.
-  // Lead with "Reopened" wording when applicable so the maintainer sees
-  // immediately why the issue is back in their inbox.
-  const lines = wasClosed
-    ? [`Reopened by [run ${context.runId}](${runUrl}) — findings changed since this issue was closed:`, ``]
-    : [`State changed in [run ${context.runId}](${runUrl}):`, ``];
+  const oldFilesRaw = extractMarker(existing.body, 'drift-files');
+  const oldFiles = new Set(oldFilesRaw ? oldFilesRaw.split(',').filter(Boolean) : []);
+  const newFiles = new Set(drift.files);
+  const added = [...newFiles].filter(f => !oldFiles.has(f)).sort();
+  const removed = [...oldFiles].filter(f => !newFiles.has(f)).sort();
+  const lines = [`State changed in [run ${context.runId}](${runUrl}):`, ``];
+  if (added.length) lines.push(`- **Now changed (${added.length}):** ${added.map(f => `\`${f}\``).join(', ')}`);
+  if (removed.length) lines.push(`- **No longer changed (${removed.length}):** ${removed.map(f => `\`${f}\``).join(', ')}`);
+  lines.push(`- Hash: ${oldHash || 'none'} → ${drift.hash}`);
+
+  await github.rest.issues.createComment({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: existing.number,
+    body: lines.join('\n'),
+  });
+  core.info(`Updated override-review #${existing.number}: hash ${oldHash || 'none'} → ${drift.hash}.`);
+  return { blocked: true };
+}
+
+module.exports = async function fileCveIssue({ github, context, core, opts }) {
+  const { kind, tag, upstream, image, severity, dockerfileSource, source, jsonPath, jsonPaths } = opts;
+  if (!['cve-findings', 'cve-resolved', 'override-review'].includes(kind)) {
+    throw new Error(`Invalid kind: ${kind}`);
+  }
+  if (!tag) {
+    throw new Error('tag is required');
+  }
+  if ((kind === 'cve-findings' || kind === 'cve-resolved') && !['build', 'rescan'].includes(source)) {
+    throw new Error(`source must be 'build' or 'rescan' for kind ${kind}`);
+  }
+
+  const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+  const securityUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/security`;
+
   if (kind === 'override-review') {
-    const oldFilesRaw = extractMarker(existing.body, 'drift-files');
-    const oldFiles = new Set(oldFilesRaw ? oldFilesRaw.split(',').filter(Boolean) : []);
-    const newFiles = new Set(drift.files);
-    const added = [...newFiles].filter(f => !oldFiles.has(f)).sort();
-    const removed = [...oldFiles].filter(f => !newFiles.has(f)).sort();
-    if (added.length) lines.push(`- **Now changed (${added.length}):** ${added.map(f => `\`${f}\``).join(', ')}`);
-    if (removed.length) lines.push(`- **No longer changed (${removed.length}):** ${removed.map(f => `\`${f}\``).join(', ')}`);
-    lines.push(`- Hash: ${oldHash || 'none'} → ${newHash}`);
-  } else {
-    const oldCvesRaw = extractMarker(existing.body, 'findings-cves');
-    const oldCves = new Set(oldCvesRaw ? oldCvesRaw.split(',').filter(Boolean) : []);
-    const newCves = new Set(findings.cves);
-    const added = [...newCves].filter(c => !oldCves.has(c)).sort();
-    const removed = [...oldCves].filter(c => !newCves.has(c)).sort();
-    if (added.length) lines.push(`- **Added (${added.length}):** ${added.join(', ')}`);
-    if (removed.length) lines.push(`- **Cleared (${removed.length}):** ${removed.join(', ')}`);
-    lines.push(`- Total now: ${findings.cves.length} unique CVE${findings.cves.length === 1 ? '' : 's'}`);
+    return handleOverrideReview({ github, context, core, opts, runUrl });
+  }
+
+  const marker = `<!-- mirror-build:cve:${tag} -->`;
+  let existing = await findIssueByMarker({ github, context, marker, labelFilter: 'cve' });
+  if (!existing) {
+    existing = await adoptOrMigrateLegacy({ github, context, core, tag, newMarker: marker });
+  }
+
+  if (kind === 'cve-resolved') {
+    if (!existing) {
+      core.info(`No CVE issue exists for tag ${tag} — nothing to resolve.`);
+      return { blocked: false };
+    }
+
+    const currentSource = extractMarker(existing.body, 'last-scan-source');
+    const currentStatus = extractMarker(existing.body, 'last-scan-status');
+
+    if (source === 'rescan' && currentSource === 'build' && currentStatus === 'open') {
+      // Build currently blocked — rescan can only annotate, not close.
+      await github.rest.issues.createComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: existing.number,
+        body: `Rescan [run ${context.runId}](${runUrl}) found the deployed image clean against \`${image}:${tag}\`, but a new build is currently blocked. Issue stays open until build resolves.`,
+      });
+      core.info(`Rescan-clean while build pending — annotated #${existing.number}, body untouched.`);
+      return { blocked: false };
+    }
+
+    if (existing.state === 'closed') {
+      core.info(`Issue #${existing.number} already closed — no-op.`);
+      return { blocked: false };
+    }
+
+    const emptyFindings = { rows: [], cves: [], hash: 'none', table: '_No CRITICAL or HIGH findings with available fix._' };
+    const newBody = renderCveBody({
+      tag, upstream, image, severity, dockerfileSource,
+      findings: emptyFindings,
+      source,
+      status: 'resolved',
+      runUrl, securityUrl,
+    });
+    await github.rest.issues.update({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: existing.number,
+      body: newBody,
+      state: 'closed',
+      state_reason: 'completed',
+    });
+    await github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: existing.number,
+      body: `Resolved by ${source} [run ${context.runId}](${runUrl}). Trivy clean — closing.`,
+    });
+    core.info(`Closed issue #${existing.number} for tag ${tag} via ${source} resolution.`);
+    return { blocked: false };
+  }
+
+  // kind === 'cve-findings'
+  const findings = loadFindings(jsonPaths || jsonPath);
+  const title = `CVE tracking: ${upstream || image} @ ${tag}`;
+
+  if (!existing) {
+    const body = renderCveBody({
+      tag, upstream, image, severity, dockerfileSource,
+      findings, source, status: 'open',
+      runUrl, securityUrl,
+    });
+    const created = await github.rest.issues.create({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      title, body,
+      labels: ['cve', 'security'],
+    });
+    core.info(`Created issue #${created.data.number} for tag ${tag} (source: ${source}, ${findings.cves.length} CVEs, hash: ${findings.hash}).`);
+    return { blocked: true };
+  }
+
+  const currentSource = extractMarker(existing.body, 'last-scan-source');
+  const currentStatus = extractMarker(existing.body, 'last-scan-status');
+
+  // Pending-build override: rescan never overwrites a body that's currently
+  // owned by an open build state. It posts a comment so the audit trail
+  // captures the rescan result, but the body stays build-flavored until the
+  // build resolves.
+  if (source === 'rescan' && currentSource === 'build' && currentStatus === 'open') {
+    const summary = findings.cves.length === 0
+      ? 'rescan clean'
+      : `${findings.cves.length} CVE${findings.cves.length === 1 ? '' : 's'}: ${findings.cves.join(', ')}`;
+    await github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: existing.number,
+      body: `Rescan [run ${context.runId}](${runUrl}) against deployed image \`${image}:${tag}\` — ${summary}.\n\nBody unchanged because a new build is currently blocked (build view takes precedence on the body).`,
+    });
+    core.info(`Pending-build override active — rescan posted comment on #${existing.number}, body untouched.`);
+    return { blocked: true };
+  }
+
+  const oldHash = extractMarker(existing.body, 'findings-sha256');
+  const newHash = findings.hash;
+  const wasClosed = existing.state === 'closed';
+
+  if (wasClosed && oldHash === newHash) {
+    // Maintainer closed with this exact finding-set; honor the decision.
+    core.info(`Closed issue #${existing.number} matches current findings (hash ${newHash}); honoring close.`);
+    return { blocked: false };
+  }
+
+  if (!wasClosed && oldHash === newHash && currentSource === source && currentStatus === 'open') {
+    core.info(`Issue #${existing.number} already current (hash ${newHash}, source ${source}). No-op.`);
+    return { blocked: true };
+  }
+
+  const newBody = renderCveBody({
+    tag, upstream, image, severity, dockerfileSource,
+    findings, source, status: 'open',
+    runUrl, securityUrl,
+  });
+  await github.rest.issues.update({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: existing.number,
+    body: newBody,
+    state: 'open',
+  });
+
+  const lines = wasClosed
+    ? [`Reopened by ${source} [run ${context.runId}](${runUrl}) — findings changed since this issue was closed:`, ``]
+    : [`Updated by ${source} [run ${context.runId}](${runUrl}):`, ``];
+  const oldCvesRaw = extractMarker(existing.body, 'findings-cves');
+  const oldCves = new Set(oldCvesRaw ? oldCvesRaw.split(',').filter(Boolean) : []);
+  const newCves = new Set(findings.cves);
+  const added = [...newCves].filter(c => !oldCves.has(c)).sort();
+  const removed = [...oldCves].filter(c => !newCves.has(c)).sort();
+  if (added.length) lines.push(`- **Added (${added.length}):** ${added.join(', ')}`);
+  if (removed.length) lines.push(`- **Cleared (${removed.length}):** ${removed.join(', ')}`);
+  lines.push(`- Total now: ${findings.cves.length} unique CVE${findings.cves.length === 1 ? '' : 's'}`);
+  if (currentSource && currentSource !== source) {
+    lines.push(`- Source: ${currentSource} → ${source}`);
   }
 
   await github.rest.issues.createComment({
@@ -424,7 +588,6 @@ module.exports = async function fileCveIssue({ github, context, core, opts }) {
     issue_number: existing.number,
     body: lines.join('\n'),
   });
-
-  core.info(`Updated issue #${existing.number}: hash ${oldHash || 'none'} → ${newHash}.`);
+  core.info(`Updated issue #${existing.number}: hash ${oldHash || 'none'} → ${newHash}, source ${currentSource || 'none'} → ${source}.`);
   return { blocked: true };
 };

--- a/.github/workflows/mirror-build.yml
+++ b/.github/workflows/mirror-build.yml
@@ -513,6 +513,29 @@ jobs:
             APT_REFRESH=${{ steps.apt-refresh.outputs.date }}
           cache-from: type=gha
 
+      # Inverse gate parallel to `Close CVE issue if scan clean` above: a
+      # successful push by definition means the just-pushed image passed
+      # Trivy at build time, which strictly supersedes any open rescan
+      # issue against the previously-deployed image at the same tag. Close
+      # it here so the issue tracker reflects ground truth without waiting
+      # for the next scheduled rescan (~24h cadence).
+      - name: Close rescan issue (push superseded the deployed image)
+        uses: actions/github-script@v7
+        env:
+          NEW_TAG: ${{ needs.check-upstream.outputs.new_tag }}
+          IMG:     ${{ env.IMAGE_NAME }}
+        with:
+          script: |
+            const fileCveIssue = require('./.github/scripts/file-cve-issue.js');
+            await fileCveIssue({
+              github, context, core,
+              opts: {
+                kind: 'rescan-resolved',
+                tag: process.env.NEW_TAG,
+                image: process.env.IMG,
+              },
+            });
+
       # --- Open a PR with the digest pin -------------------------------------
       # Human approval gate. The PR body is the summary; the workflow-run
       # artifacts are the evidence. On merge, image-pin.yml hits main and

--- a/.github/workflows/mirror-build.yml
+++ b/.github/workflows/mirror-build.yml
@@ -430,7 +430,7 @@ jobs:
       # Either scan failing is enough to block the push. One issue per tag
       # collects findings from both — see file-cve-issue.js (jsonPaths array).
       # Idempotent: re-runs against the same tag won't spam duplicate issues.
-      - name: File or update CVE issue
+      - name: File or update CVE issue (build findings)
         if: always() && (steps.trivy-scan.outcome == 'failure' || steps.trivy-fs.outcome == 'failure')
         uses: actions/github-script@v7
         env:
@@ -445,7 +445,8 @@ jobs:
             await fileCveIssue({
               github, context, core,
               opts: {
-                kind: 'block',
+                kind: 'cve-findings',
+                source: 'build',
                 tag: process.env.NEW_TAG,
                 upstream: process.env.UPSTREAM,
                 image: process.env.IMG,
@@ -455,25 +456,34 @@ jobs:
               },
             });
 
-      # Inverse gate: Trivy passed for this tag this run, so any open `block`
-      # issue from a previous (failing) run for the same tag is now stale.
-      # The helper looks it up by marker, posts a "resolved by run X" comment,
-      # and closes it. No-op if no such issue exists or it's already closed.
-      - name: Close CVE issue if scan clean
+      # Inverse gate: Trivy passed for this tag this run, so any open CVE
+      # issue for the same tag is now stale. The helper looks it up by marker
+      # (unified `cve:<tag>` — both former `block` and `rescan` lifetimes
+      # share one issue), posts a "resolved by build run X" comment, updates
+      # the body to a `resolved` state, and closes. No-op if no such issue
+      # exists or it's already closed.
+      - name: Resolve CVE issue (build clean)
         if: steps.trivy-scan.outcome == 'success' && steps.trivy-fs.outcome == 'success'
         uses: actions/github-script@v7
         env:
-          NEW_TAG: ${{ needs.check-upstream.outputs.new_tag }}
-          IMG:     ${{ env.IMAGE_NAME }}
+          NEW_TAG:  ${{ needs.check-upstream.outputs.new_tag }}
+          UPSTREAM: ${{ env.UPSTREAM_REPO }}
+          IMG:      ${{ env.IMAGE_NAME }}
+          SEV:      ${{ env.TRIVY_SEVERITY }}
+          DFSRC:    ${{ steps.override.outputs.dockerfile_source }}
         with:
           script: |
             const fileCveIssue = require('./.github/scripts/file-cve-issue.js');
             await fileCveIssue({
               github, context, core,
               opts: {
-                kind: 'block-resolved',
+                kind: 'cve-resolved',
+                source: 'build',
                 tag: process.env.NEW_TAG,
+                upstream: process.env.UPSTREAM,
                 image: process.env.IMG,
+                severity: process.env.SEV,
+                dockerfileSource: process.env.DFSRC,
               },
             });
 
@@ -512,29 +522,6 @@ jobs:
             VERSION=${{ needs.check-upstream.outputs.new_tag }}
             APT_REFRESH=${{ steps.apt-refresh.outputs.date }}
           cache-from: type=gha
-
-      # Inverse gate parallel to `Close CVE issue if scan clean` above: a
-      # successful push by definition means the just-pushed image passed
-      # Trivy at build time, which strictly supersedes any open rescan
-      # issue against the previously-deployed image at the same tag. Close
-      # it here so the issue tracker reflects ground truth without waiting
-      # for the next scheduled rescan (~24h cadence).
-      - name: Close rescan issue (push superseded the deployed image)
-        uses: actions/github-script@v7
-        env:
-          NEW_TAG: ${{ needs.check-upstream.outputs.new_tag }}
-          IMG:     ${{ env.IMAGE_NAME }}
-        with:
-          script: |
-            const fileCveIssue = require('./.github/scripts/file-cve-issue.js');
-            await fileCveIssue({
-              github, context, core,
-              opts: {
-                kind: 'rescan-resolved',
-                tag: process.env.NEW_TAG,
-                image: process.env.IMG,
-              },
-            });
 
       # --- Open a PR with the digest pin -------------------------------------
       # Human approval gate. The PR body is the summary; the workflow-run
@@ -727,11 +714,12 @@ jobs:
           exit-code: '0'
           ignore-unfixed: true
 
-      - name: File or update CVE issue
+      - name: File or update CVE issue (rescan findings)
         if: steps.last.outputs.should_scan == 'true' && steps.trivy-rescan.outcome == 'failure'
         uses: actions/github-script@v7
         env:
           LAST_TAG: ${{ steps.last.outputs.last_tag }}
+          UPSTREAM: ${{ env.UPSTREAM_REPO }}
           IMG:      ${{ env.IMAGE_NAME }}
           SEV:      ${{ env.TRIVY_SEVERITY }}
         with:
@@ -740,32 +728,41 @@ jobs:
             await fileCveIssue({
               github, context, core,
               opts: {
-                kind: 'rescan',
+                kind: 'cve-findings',
+                source: 'rescan',
                 tag: process.env.LAST_TAG,
+                upstream: process.env.UPSTREAM,
                 image: process.env.IMG,
                 severity: process.env.SEV,
                 jsonPath: 'trivy-rescan.json',
               },
             });
 
-      # Inverse gate: rescan passed clean for last_tag, so any open `rescan`
-      # issue from a previous nightly is stale. Same close-on-resolve helper
-      # call as in the build job, with the rescan marker shape.
-      - name: Close rescan issue if rescan clean
+      # Inverse gate: rescan passed clean for last_tag, so any open CVE issue
+      # for the same tag is now stale (or at least: the deployed image is
+      # currently clean). Same call as in the build job, with source=rescan.
+      # The helper's pending-build override ensures this won't close the issue
+      # if a parallel build is currently blocked.
+      - name: Resolve CVE issue (rescan clean)
         if: steps.last.outputs.should_scan == 'true' && steps.trivy-rescan.outcome == 'success'
         uses: actions/github-script@v7
         env:
           LAST_TAG: ${{ steps.last.outputs.last_tag }}
+          UPSTREAM: ${{ env.UPSTREAM_REPO }}
           IMG:      ${{ env.IMAGE_NAME }}
+          SEV:      ${{ env.TRIVY_SEVERITY }}
         with:
           script: |
             const fileCveIssue = require('./.github/scripts/file-cve-issue.js');
             await fileCveIssue({
               github, context, core,
               opts: {
-                kind: 'rescan-resolved',
+                kind: 'cve-resolved',
+                source: 'rescan',
                 tag: process.env.LAST_TAG,
+                upstream: process.env.UPSTREAM,
                 image: process.env.IMG,
+                severity: process.env.SEV,
               },
             });
 

--- a/.github/workflows/mirror-build.yml
+++ b/.github/workflows/mirror-build.yml
@@ -631,6 +631,7 @@ jobs:
       packages: read
       security-events: write     # Upload SARIF to Security tab
       issues: write              # File issue on new findings
+      pull-requests: write       # Auto-close stale mirror-build PR when rescan surfaces findings
       actions: read              # Required by codeql-action/upload-sarif telemetry
 
     steps:


### PR DESCRIPTION
Consolidates per-tag CVE tracking into one issue across both build-time and post-release rescan events, plus interlocks PR state to issue state.

**Per-tag CVE issue consolidation:**
- Marker unified to `<!-- mirror-build:cve:<tag> -->` (was `cve-block:`/`cve-rescan:`).
- Issue title tag-stable: `CVE tracking: <upstream> @ <tag>`.
- Body always reflects last scan; header line identifies source (build vs rescan) and status.
- State transitions add diff comments — full audit history per version preserved.
- Closed issues reopen on new findings; honored if maintainer closed at matching hash.
- Pending-build override: rescan won't overwrite body while a build is currently blocked, only annotates via comment.
- Labels reduced to `cve` + `security` (`blocked`/`rescan` removed).
- Legacy migration: on first run against a tag with old `cve-block:`/`cve-rescan:` issues, the helper adopts the highest-numbered one as canonical and closes the others as superseded.

**PR interlock (NEW in second commit):**
- When a CVE issue surfaces findings against a tag (create / reopen / body-changed), the helper also closes any open `mirror-build/<tag>` PR with an audit comment.
- Prevents a closed-then-reopened CVE issue from leaving a green PR that would roll out a now-known-vulnerable image.
- Self-heals: next clean build force-pushes the branch and the PR-open step files a fresh PR.
- Maintainer override: manually re-open the closed PR to accept the finding (audit trail stays on the maintainer).
- Rescan job permissions extended with `pull-requests: write` (was read-only).