### PR TITLE
chore(cve): apt-get upgrade pass + waive cloudflared Go 1.26.2 stdlib family

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -336,3 +336,56 @@ CVE-2026-39883
 #
 # Revisit when Cloudflare ships a fresh cloudflared .deb, or 2026-09.
 CVE-2026-29181
+
+# CVE-2026-33811, CVE-2026-33814, CVE-2026-39820, CVE-2026-39836, CVE-2026-42499
+# — Go stdlib DoS family, this time vendored in cloudflared at Go 1.26.2.
+# Fix: stdlib >= 1.25.10 / 1.26.3.
+#
+# Background — why this is a separate waiver block from the 25679/32280/...
+# group above: between 2026-05-03 (uptime-kuma 2.3.2 release) and 2026-05-20
+# Cloudflare republished cloudflared with a fresh Go toolchain, jumping
+# 1.24.13 -> 1.26.2. That cleared the four 1.24.13 DoS CVEs (which is why
+# they have not regressed) but exposed five new 1.26.2 stdlib CVEs that
+# weren't yet known when Cloudflare cut the package. Same library, same
+# binary path (/usr/bin/cloudflared), same reachability story as the
+# 1.24.13 waiver block — just chasing a moving Go-version target. The
+# 1.24.13 CVE IDs above stay listed for audit-trail continuity (deleting
+# them would erase the history that those CVEs were ever waived, and
+# Trivy ignores already-cleared IDs harmlessly).
+#
+# Per-CVE shape:
+#   - CVE-2026-33811 (HIGH) — LookupCNAME with cgo DNS resolver: a very
+#     long CNAME response causes resource exhaustion in the resolver.
+#   - CVE-2026-33814 (HIGH) — HTTP/2 SETTINGS frame handling enters an
+#     infinite loop on a crafted frame, hanging the transport.
+#   - CVE-2026-39820 (HIGH) — net/mail ParseAddress*/ParseAddressList
+#     pathological inputs cause DoS.
+#   - CVE-2026-39836 (HIGH) — Windows-only panic in Dial/LookupPort on
+#     NUL bytes in net inputs. Our container runs Linux — the panic path
+#     is platform-gated dead code here. Listed anyway for completeness.
+#   - CVE-2026-42499 (HIGH) — pathological inputs to net/mail
+#     consumePhrase cause DoS during header parsing.
+#
+# Reachability in our deployment is identical to the 1.24.13 block above
+# and the otel/grpc waivers below:
+#   1. cloudflared sits idle unless a Cloudflare Tunnel monitor is
+#      explicitly configured in uptime-kuma's UI — we don't run one in
+#      any deployment of this image.
+#   2. Even when active, cloudflared connects as a CLIENT to Cloudflare's
+#      edge. The DoS-class inputs would need to come from a Cloudflare-
+#      edge compromise, outside our threat model.
+#   3. CVE-2026-39836 is platform-gated to Windows; not reachable on
+#      Linux containers regardless of monitor configuration.
+#
+# Cloudflare can't bump Go faster than upstream Go cuts patch releases;
+# 1.26.3 landed 2026-05-19 and will reach pkg.cloudflare.com in a fresh
+# .deb on Cloudflare's usual ~few-weeks cadence. Until then, these are
+# version-match findings without a code path that an attacker reaches.
+#
+# Revisit when Cloudflare ships a fresh cloudflared .deb (typically every
+# few weeks; check pkg.cloudflare.com), or 2026-09 — whichever first.
+CVE-2026-33811
+CVE-2026-33814
+CVE-2026-39820
+CVE-2026-39836
+CVE-2026-42499

--- a/dockerfiles/Dockerfile.override
+++ b/dockerfiles/Dockerfile.override
@@ -110,8 +110,18 @@ LABEL org.opencontainers.image.source="https://github.com/louislam/uptime-kuma" 
 # slipped in via Recommends despite --no-install-recommends. The first line
 # threads APT_REFRESH into this layer's hash so daily rebuilds re-resolve
 # apt rather than reusing a stale cached layer (see ARG APT_REFRESH above).
+#
+# `apt-get upgrade -y` sweeps the BASE IMAGE's pre-installed packages
+# forward to the current bookworm-security state. Without it, libraries
+# inherited from node:22-bookworm-slim (e.g. libgnutls30, libssl3, libc6)
+# stay pinned to whatever version the base image shipped with — daily
+# Debian security advisories only land when Docker Hub republishes the
+# base tag (~weekly). The cache-bust above keeps apt indexes fresh; this
+# line is what actually applies them. Subsequent stages (3b/3c/3d) only
+# `install` new packages, so the upgrade pass needs to run once here.
 RUN echo "apt-refresh=${APT_REFRESH}" > /etc/.apt-refresh && \
     apt-get update && \
+    apt-get -y upgrade && \
     apt-get install --no-install-recommends -y \
       sqlite3 \
       ca-certificates \


### PR DESCRIPTION
## Summary

Follow-up to #11 to close the remaining 11 findings against the deployed 2.3.2 image (issue #6). After #11 landed, the first rebuild surfaced two new CVE buckets — both root-caused, both addressed surgically:

- **`libgnutls30` (6 CVEs, 2× CRITICAL + 4× HIGH):** root cause is a workflow design gap, not a fresh upstream issue. `libgnutls30 3.7.9-2+deb12u6` lives in the pinned `node:22-bookworm-slim` base image (it's a hard dependency of `apt` itself); Debian's bookworm-security has `+deb12u7` published, but our `apt-get install <new-pkg>` calls never *upgrade* pre-installed packages — only the daily `APT_REFRESH` cache-bust + `apt-get update` runs, indexes get refreshed but never applied to inherited libraries. Fix: add `apt-get -y upgrade` to stage 3a right after the cache-bust line. Generalizes for free — any base-image-inherited library now tracks Debian's daily security cadence instead of Docker Hub's weekly base-image rebuild cadence.
- **cloudflared Go 1.26.2 stdlib (5 CVEs, all HIGH):** Cloudflare republished cloudflared between 2026-05-03 and 2026-05-20 with a fresh Go toolchain (`1.24.13 -> 1.26.2`), which cleared the four 1.24.13 DoS CVEs we previously waived but exposed five new stdlib CVEs for the newer Go version. Same library, same `/usr/bin/cloudflared` binary path, same reachability story as the existing cloudflared waiver block. Go 1.26.3 landed upstream on 2026-05-19; pkg.cloudflare.com will pick it up on Cloudflare's usual cadence. Until then: waive in `.trivyignore` with full per-CVE shape analysis, the version-chase context, the unchanged reachability argument, and the existing revisit triggers.

## Reachability summary for the libgnutls30 batch (informational — not the fix path)

Three of six are DTLS-only (`CVE-2026-33845`, `-33846`, `-42009`); uptime-kuma is HTTP/HTTPS over TCP, no DTLS code path exists in the image. One is TLS username-auth (`CVE-2026-42010`, SRP/PSK); GnuTLS only ever runs as a client here (via `apt` at build time, possibly `curl` at runtime), where a server-auth bypass is meaningless. Two are x509-nameConstraints (`CVE-2026-3833`, `-42011`); requires attacker control of a constrained sub-CA in a chain we validate against, which is not a configuration we run. So the criticality on paper is high (2× CRITICAL) but the reachable attack surface in this image is effectively nil. Even so, the structural `apt-get upgrade` fix is the right move — it costs nothing extra to apply and removes the need to argue reachability for every future base-image-inherited CVE.

## Expected post-merge scan delta

| Bucket | Before this PR | After this PR + rebuild |
|---|---|---|
| `libgnutls30` (6 HIGH/CRIT, base-image-inherited) | open | cleared by `apt-get upgrade` |
| cloudflared Go 1.26.2 stdlib (5 HIGH) | open | waived with audit-trail block |
| protobufjs 7.2.6 (4 HIGH) | waived (#11) | unchanged |
| cloudflared Go 1.24.13 stdlib + otel + grpc + go-jose | waived (historical) | unchanged, audit-trail preserved |
| OS / apt | 0 | 0 |

Net goal: **issue #6 closes at 0 actionable findings.**

## Test plan

- [ ] Verify the `apt-get upgrade -y` placement in stage 3a is between `apt-get update` and the package `install` block — required for the upgrade to use the freshly-refreshed indexes.
- [ ] Confirm the new `.trivyignore` block's reachability arguments still match this deployment (no Cloudflare Tunnel monitor configured, Linux-only container).
- [ ] Merge → trigger Actions → "OSS Mirror Build" → Run workflow on `main`.
- [ ] Verify the SARIF in the Security tab shows: zero libgnutls30 findings (upgrade pass picked up `+deb12u7`), and zero unwaived stdlib findings on `/usr/bin/cloudflared`.
- [ ] Verify build-time CVE issue #6 closes automatically once the rebuild publishes.
- [ ] Sanity-check the image still boots and healthcheck succeeds (no library got upgraded into something incompatible — unlikely within Bookworm point-release line, but worth a one-shot run).

## Risk

Low. `apt-get upgrade` within a single Debian stable release is the intended security-update path — same operation Debian recommends for any long-running Bookworm host. The waiver additions are documentation-only changes that suppress Trivy noise; reverting either change is a single-commit rollback. Image size grows marginally (only by the delta of upgraded packages over what was in the pinned base).